### PR TITLE
Removed all use of CONCAT to support SQL Server 2008 R2

### DIFF
--- a/sqlserver/sampledb/v1/install-onprem.sql
+++ b/sqlserver/sampledb/v1/install-onprem.sql
@@ -16,7 +16,7 @@
 
 
 PRINT('Installing AWS sampledb in database dms_sample...')
-PRINT(CONCAT('Starting: ',CURRENT_TIMESTAMP));
+-- PRINT(CONCAT('Starting: ',CURRENT_TIMESTAMP));
 GO
 
 :setvar BACKUPDIR aws_sampledb_backups
@@ -175,7 +175,7 @@ print('Setting up replication...')
 go
 :r .\system\enable_replication.sql
 
-PRINT(CONCAT('Complete: ',CURRENT_TIMESTAMP));
+-- PRINT(CONCAT('Complete: ',CURRENT_TIMESTAMP));
 GO
 Print('.....   Done   .....')
 GO

--- a/sqlserver/sampledb/v1/remove-sampledb.sql
+++ b/sqlserver/sampledb/v1/remove-sampledb.sql
@@ -18,7 +18,7 @@
 print('Removing database dms_sample and login dms_user...')
 go
 
-PRINT(CONCAT('Start: ',CURRENT_TIMESTAMP));
+-- PRINT(CONCAT('Start: ',CURRENT_TIMESTAMP));
 GO
 
 print('Removing replication...')
@@ -80,7 +80,7 @@ EXEC sp_dropdevice 'dms_sample_backup';
 EXEC sp_dropdevice 'dms_sample_log';
 
 
-PRINT(CONCAT('Complete: ',CURRENT_TIMESTAMP));
+-- PRINT(CONCAT('Complete: ',CURRENT_TIMESTAMP));
 GO
 
 Print('.....   Done   .....')

--- a/sqlserver/sampledb/v1/schema/generateTicketActivity.sql
+++ b/sqlserver/sampledb/v1/schema/generateTicketActivity.sql
@@ -58,7 +58,7 @@ BEGIN TRY
 	    exec dbo.sellTickets @person_id, @event_id, @quantity;
         SET @current_txn = @current_txn +1;
 	    -- WAITFOR DELAY '00:00:00.01'; /* we can add this in the future if needed. */
-        PRINT(CONCAT('event:',@event_id, ' person:', @person_id,' quantity: ',@quantity));
+        -- PRINT(CONCAT('event:',@event_id, ' person:', @person_id,' quantity: ',@quantity));
 	  END TRY
 	  BEGIN CATCH
 	    SET @reset_events = 1;  -- If we fail to sell tickets to this event, we reload the open events table as this one is sold out

--- a/sqlserver/sampledb/v1/schema/generateTransferActivity.sql
+++ b/sqlserver/sampledb/v1/schema/generateTransferActivity.sql
@@ -38,7 +38,7 @@ BEGIN TRY
   -- get max and min person ids
   SELECT @min_p_id = min(id), @max_p_id = max(id) FROM person;
 
-  print(concat('max t: ',@max_tik_id,' min t: ', @min_tik_id, 'max p: ',@max_p_id,' min p: ', @min_p_id));
+  -- print(concat('max t: ',@max_tik_id,' min t: ', @min_tik_id, 'max p: ',@max_p_id,' min p: ', @min_p_id));
 
   WHILE @txn_count < @max_transactions
   BEGIN
@@ -64,7 +64,7 @@ BEGIN TRY
     FROM   sporting_event_ticket
     WHERE  id = @tik_id;
 
- 	PRINT(CONCAT('Ticket to transfer: ', @tik_id, ' Transfer to person id: ' , @person_id, ' All tickets?: ',@xfer_all, ' price: ', @price));
+ 	-- PRINT(CONCAT('Ticket to transfer: ', @tik_id, ' Transfer to person id: ' , @person_id, ' All tickets?: ',@xfer_all, ' price: ', @price));
 
     exec dbo.transferTicket @tik_id, @person_id, @xfer_all, @price ;
 

--- a/sqlserver/sampledb/v1/schema/generate_mlb_season.sql
+++ b/sqlserver/sampledb/v1/schema/generate_mlb_season.sql
@@ -52,8 +52,8 @@ BEGIN
      --- start on the closest saturday to mar 31 of the current year
      DECLARE @event_date DATETIME;
      DECLARE @day_increment INT;
-     SET @day_increment = 6 - DATEPART(WEEKDAY,CAST(CONCAT('31-MAR',YEAR(GETDATE())) AS DATETIME));
-     SET @event_date =  CAST(CONCAT('31-MAR',YEAR(GETDATE())) AS DATETIME) + @day_increment + 7*@date_offset;
+     SET @day_increment = 6 - DATEPART(WEEKDAY, CAST('31-MAR' + CAST(YEAR(GETDATE()) AS NVARCHAR(4)) AS DATETIME));
+     SET @event_date =  CAST('31-MAR' + CAST(YEAR(GETDATE()) AS NVARCHAR(4)) AS DATETIME) + @day_increment + 7*@date_offset;
 
 	 OPEN @team2;
 	 FETCH NEXT

--- a/sqlserver/sampledb/v1/schema/generate_nfl_season.sql
+++ b/sqlserver/sampledb/v1/schema/generate_nfl_season.sql
@@ -82,8 +82,8 @@ BEGIN
 	  AND sport_league_short_name = 'NFL'
 	  ORDER BY id;
 
-	  SET @day_increment = DATEPART(WEEKDAY,CAST(CONCAT('01-SEP',YEAR(GETDATE())) AS DATETIME))-1;
-	  SET @event_date = CAST(CONCAT('01-SEP',YEAR(GETDATE())) AS DATETIME) - @day_increment + 7*@date_offset;
+      SET @day_increment = DATEPART(WEEKDAY, CAST('01-SEP' + CAST(YEAR(GETDATE()) AS NVARCHAR(4)) AS DATETIME))-1;
+	  SET @event_date = CAST('01-SEP' + CAST(YEAR(GETDATE()) AS NVARCHAR(4)) AS DATETIME) - @day_increment + 7*@date_offset;
 
 	  OPEN @team2;
       FETCH NEXT FROM @team2 INTO @team2_id, @team2_home_field_id;

--- a/sqlserver/sampledb/v1/schema/person.tab
+++ b/sqlserver/sampledb/v1/schema/person.tab
@@ -9,7 +9,7 @@ create table person
 
 
 INSERT INTO person(full_name, last_name, first_name)
-SELECT CONCAT(first.name,' ',last.name)
+SELECT first.name + ' ' + last.name
        ,last.name
        ,first.name
 FROM   name_data first, name_data last

--- a/sqlserver/sampledb/v1/schema/sellTickets.sql
+++ b/sqlserver/sampledb/v1/schema/sellTickets.sql
@@ -68,7 +68,7 @@ BEGIN TRY
 		  FROM @ticket_ids;
 		  DELETE FROM @ticket_ids;
 
-		  PRINT(CONCAT('Sold ',@rows_updated,' seats - level: ',@seat_level,' section: ',@seat_section,' row: ',@seat_row));
+		  -- PRINT(CONCAT('Sold ',@rows_updated,' seats - level: ',@seat_level,' section: ',@seat_section,' row: ',@seat_row));
 
    	      SET @success = 1;
 		  COMMIT;

--- a/sqlserver/sampledb/v1/schema/transferTicket.sql
+++ b/sqlserver/sampledb/v1/schema/transferTicket.sql
@@ -55,7 +55,7 @@ BEGIN TRY
 	INSERT INTO ticket_purchase_hist(sporting_event_ticket_id, purchased_by_id, transferred_from_id, transaction_date_time, purchase_price)
     VALUES(@sporting_event_ticket_id, @new_ticketholder_id, @old_ticketholder_id, current_timestamp, ISNULL(@price,@purchase_price)); 
 
-	PRINT(CONCAT('Ticket id: ', @sporting_event_ticket_id, ' Original price: ', @purchase_price, ' Old Ticketholder: ',@old_ticketholder_id,' Txn Date: ', @last_txn_date));
+	-- PRINT(CONCAT('Ticket id: ', @sporting_event_ticket_id, ' Original price: ', @purchase_price, ' Old Ticketholder: ',@old_ticketholder_id,' Txn Date: ', @last_txn_date));
 
     FETCH @xfer_cur INTO @sporting_event_ticket_id, @purchase_price;
   END;


### PR DESCRIPTION
I would like to use this database for a upcoming workshop on migrating from SQL Server 2008. The current scripts do not run on SQL Server 2008 because they use CONCAT which was added in SQL Server 2012. Note that I was lazy and commented out a few uses of CONCAT that were only logging to the console.